### PR TITLE
[AI Accelerators] Update torch.nn.functional multi_head_attention_forward(). Add pastpath

### DIFF
--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -70,7 +70,7 @@ Tensor _cudnn_init_dropout_state(double dropout, bool train, int64_t dropout_see
     c10::optional<Device> device,
     c10::optional<bool> pin_memory) {
   // See [Note: hacky wrapper removal for TensorOptions]
-  TensorOptions options = TensorOptions().dtype(dtype).layout(layout).device(device).pinned_memory(pin_memory);
+  TensorOptions().dtype(dtype).layout(layout).device(device).pinned_memory(pin_memory);
 
   AT_ERROR("_cudnn_init_dropout_state: ATen not compiled with cuDNN support");
 }

--- a/caffe2/perfkernels/batch_box_cox_avx2.cc
+++ b/caffe2/perfkernels/batch_box_cox_avx2.cc
@@ -1,3 +1,4 @@
+#include <immintrin.h>
 #ifdef CAFFE2_PERF_USE_MKL
 #include <c10/util/irange.h>
 #include <caffe2/perfkernels/common.h>
@@ -5,28 +6,66 @@
 
 #include "vectorizer.h"
 
-#ifndef VECTORIZED_KERNEL
+// Enable compiler vectorized version only if numerical consistency is not
+// required between dev and opt versions - disabled for now
+#ifndef FAST_VECTORIZED_KERNEL
 #define CPU_CAPABILITY_AVX2
 #include <ATen/cpu/vec/vec.h>
 
 namespace at::vec {
 
+// Implements the vectorized version of std::max() operation,
+// which DOESNOT propagates NaN for second argument
 template <typename scalar_t>
 Vectorized<scalar_t> max(const Vectorized<scalar_t>& a, const Vectorized<scalar_t>& b);
 
-// Implements the vectorized version of std::max() operation,
-// which DOESNOT propagates NaN for second argument
 template <>
 Vectorized<double> max(const Vectorized<double>& a, const Vectorized<double>& b) {
   // std::max(NaN, nonNan) -> NaN
   return _mm256_max_pd(b, a);
 }
 
-
 template <>
 Vectorized<float> max(const Vectorized<float>& a, const Vectorized<float>& b) {
   // std::max(NaN, nonNan) -> NaN
   return _mm256_max_ps(b, a);
+}
+
+// Implements recieprocal method based on newton-rapson method
+// 1. user RCP approximiation
+// 2. update with RCP = RCP * (2 - X * RCP)
+template <typename scalar_t>
+Vectorized<scalar_t> fast_recieprocal(const Vectorized<scalar_t>& b);
+template <typename scalar_t>
+scalar_t fast_recieprocal(scalar_t b);
+
+template<>
+Vectorized<float> fast_recieprocal(const Vectorized<float>& b) {
+  auto minus2 = _mm256_set1_ps(-2.f);
+  auto rcp = _mm256_rcp_ps(b);
+  rcp = _mm256_mul_ps(rcp,  _mm256_fnmsub_ps(rcp, b, minus2));
+  rcp = _mm256_mul_ps(rcp,  _mm256_fnmsub_ps(rcp, b, minus2));
+  return rcp;
+}
+
+template <>
+float fast_recieprocal(float b) {
+  auto minus2 = _mm_set_ss(-2.f);
+  auto b_reg = _mm_set_ss(b);
+  auto rcp = _mm_rcp_ss(b_reg);
+  rcp = _mm_mul_ss(rcp,  _mm_fnmsub_ss(rcp, b_reg, minus2));
+  rcp = _mm_mul_ss(rcp,  _mm_fnmsub_ss(rcp, b_reg, minus2));
+  return _mm_cvtss_f32(rcp);
+}
+
+template<>
+Vectorized<double> fast_recieprocal(const Vectorized<double>& b) {
+  return b.reciprocal();
+}
+
+template <>
+double fast_recieprocal(double b) {
+  return 1./b;
 }
 
 }
@@ -45,14 +84,6 @@ template <typename T>
 void PackV(const int N, const T* a, const int* ia, T* y);
 template <typename T>
 void UnpackV(const int N, const T* a, T* y, const int* iy);
-template <typename T>
-void Pow(const int N, const T* a, const T* b, T* y);
-template <typename T>
-void Add(const int N, const T* a, const T* b, T* y);
-template <typename T>
-void Div(const int N, const T* a, const T* b, T* y);
-template <typename T>
-void Ln(const int N, const T* a, T* y);
 
 #define DELEGATE_PACKV_FUNCTION(T, OriginalFunc)                \
   template <>                                                   \
@@ -72,29 +103,7 @@ DELEGATE_UNPACKV_FUNCTION(float, vsUnpackV)
 DELEGATE_UNPACKV_FUNCTION(double, vdUnpackV)
 #undef DELEGATE_UNPACKV_FUNCTION
 
-#define DELEGATE_SIMPLE_BINARY_FUNCTION(T, Funcname, OriginalFunc) \
-  template <>                                                      \
-  void Funcname<T>(const int N, const T* a, const T* b, T* y) {    \
-    OriginalFunc(N, a, b, y);                                      \
-  }
-DELEGATE_SIMPLE_BINARY_FUNCTION(float, Pow, vsPow)
-DELEGATE_SIMPLE_BINARY_FUNCTION(double, Pow, vdPow)
-DELEGATE_SIMPLE_BINARY_FUNCTION(float, Add, vsAdd)
-DELEGATE_SIMPLE_BINARY_FUNCTION(double, Add, vdAdd)
-DELEGATE_SIMPLE_BINARY_FUNCTION(float, Div, vsDiv)
-DELEGATE_SIMPLE_BINARY_FUNCTION(double, Div, vdDiv)
-#undef DELEGATE_SIMPLE_BINARY_FUNCTION
-
-#define DELEGATE_SIMPLE_UNARY_FUNCTION(T, Funcname, OriginalFunc) \
-  template <>                                                     \
-  void Funcname<T>(const int N, const T* a, T* y) {               \
-    OriginalFunc(N, a, y);                                        \
-  }
-DELEGATE_SIMPLE_UNARY_FUNCTION(float, Ln, vsLn)
-DELEGATE_SIMPLE_UNARY_FUNCTION(double, Ln, vdLn)
-#undef DELEGATE_SIMPLE_UNARY_FUNCTION
-
-#ifndef VECTORIZED_KERNEL
+#ifndef FAST_VECTORIZED_KERNEL
 template <typename T>
 void box_cox_zero_lambda(
     size_t D,
@@ -140,7 +149,7 @@ void box_cox_nonzero_lambda(
     auto sum = data + lambda2;
     auto max = at::vec::max(sum, k_eps_vec);
     auto lambda1 = Vec::loadu(lambda1_ptr + j);
-    auto lambda_over_1 = lambda1.reciprocal();
+    auto lambda_over_1 = at::vec::fast_recieprocal(lambda1);
     auto pow = max.pow(lambda1);
     auto res = at::vec::fmsub(pow, lambda_over_1, lambda_over_1);
     res.store(out + j);
@@ -148,7 +157,7 @@ void box_cox_nonzero_lambda(
   for ( ;j < D; ++j) {
     auto sum = data_ptr[j] + lambda2_ptr[j];
     auto max = std::max(sum, k_eps);
-    auto lambda_over_1 = 1 / lambda1_ptr[j];
+    auto lambda_over_1 = at::vec::fast_recieprocal(lambda1_ptr[j]);
     auto pow = std::pow(max, lambda1_ptr[j]);
     out[j] = pow * lambda_over_1 - lambda_over_1;
   }
@@ -181,12 +190,16 @@ void box_cox_nonzero_lambda(
     FAST_MATH
     auto sum = data_ptr[j] + lambda2_ptr[j];
     auto max = std::max(sum, k_eps);
-    auto lambda_over_1 = 1 / lambda1_ptr[j];
-    auto pow = std::pow(max, lambda1_ptr[j]);
+    auto lamda1 = lambda1_ptr[j];
+    auto lambda_over_1 = 1 / lamda1;
+    if constexpr (std::is_same<T, float>::value) {
+      lambda_over_1 = lambda_over_1 * (T{2} - lambda_over_1 * lamda1);
+      lambda_over_1 = lambda_over_1 * (T{2} - lambda_over_1 * lamda1);
+    }
+    auto pow = std::pow(max, lamda1);
     out[j] = pow * lambda_over_1 - lambda_over_1;
   }
 }
-
 #endif
 
 template <typename T>

--- a/test/onnx/internal/test_diagnostics.py
+++ b/test/onnx/internal/test_diagnostics.py
@@ -19,7 +19,7 @@ def _assert_has_diagnostics(
     rule_level_pairs: AbstractSet[Tuple[infra.Rule, infra.Level]],
 ):
     sarif_log = engine.sarif_log()
-    unseen_pairs = {(rule.id, level.value) for rule, level in rule_level_pairs}
+    unseen_pairs = {(rule.id, level.name.lower()) for rule, level in rule_level_pairs}
     actual_results = []
     for run in sarif_log.runs:
         if run.results is None:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -92,6 +92,7 @@ class cpp:
         "g++-10",
         "clang++",
         "g++",
+        "g++.par",
     )
 
 

--- a/torch/onnx/_internal/diagnostics/_diagnostic.py
+++ b/torch/onnx/_internal/diagnostics/_diagnostic.py
@@ -74,22 +74,6 @@ class ExportDiagnostic(infra.Diagnostic):
         self.with_stack(stack)
         self.cpp_call_stack = stack
 
-    def with_model_source_location(
-        self: _ExportDiagnostic,
-    ) -> _ExportDiagnostic:
-        # TODO: Implement this.
-        # self.locations.append(...)
-        raise NotImplementedError()
-        return self
-
-    def with_export_source_location(
-        self: _ExportDiagnostic,
-    ) -> _ExportDiagnostic:
-        # TODO: Implement this.
-        # self.locations.append(...)
-        raise NotImplementedError()
-        return self
-
 
 class ExportDiagnosticEngine(infra.DiagnosticEngine):
     """PyTorch ONNX Export diagnostic engine.
@@ -115,7 +99,6 @@ class ExportDiagnosticEngine(infra.DiagnosticEngine):
             name="torch.onnx",
             version=torch.__version__,
             diagnostic_type=ExportDiagnostic,
-            options=None,
         )
 
     @property
@@ -150,6 +133,7 @@ def create_export_diagnostic_context():
     try:
         yield context
     finally:
+        context.pretty_print(context.options.log_verbose, context.options.log_level)
         context = engine.background_context
 
 

--- a/torch/onnx/_internal/diagnostics/infra/_infra.py
+++ b/torch/onnx/_internal/diagnostics/infra/_infra.py
@@ -17,10 +17,10 @@ class Level(enum.Enum):
     please use infra.Tag instead.
     """
 
-    NONE = "none"
-    NOTE = "note"
-    WARNING = "warning"
-    ERROR = "error"
+    NONE = enum.auto()
+    NOTE = enum.auto()
+    WARNING = enum.auto()
+    ERROR = enum.auto()
 
 
 levels = Level
@@ -107,6 +107,9 @@ class Rule:
         """
         return self.message_default_template.format(*args, **kwargs)
 
+    def pretty_print(self):
+        pass
+
 
 @dataclasses.dataclass
 class Location:
@@ -134,6 +137,25 @@ class Location:
             else None,
         )
 
+    def pretty_print(self):
+        """Prints the location in a human-readable format."""
+        location_strs = ["frame:"]
+        if self.snippet is not None:
+            location_strs.append(self.snippet)
+        if self.uri is not None:
+            line_strs = [self.uri]
+            line_strs.append(str(self.line)) if self.line is not None else "-1"
+            line_strs.append(
+                str(self.start_column)
+            ) if self.start_column is not None else "-1"
+            line_strs.append(
+                str(self.end_column)
+            ) if self.end_column is not None else "-1"
+            location_strs.append(":".join(line_strs))
+        if self.message is not None:
+            location_strs.append(f"({self.message})")
+        print(" ".join(location_strs))
+
 
 @dataclasses.dataclass
 class StackFrame:
@@ -142,6 +164,10 @@ class StackFrame:
     def sarif(self) -> sarif.StackFrame:
         """Returns the SARIF representation of this stack frame."""
         return sarif.StackFrame(location=self.location.sarif())
+
+    def pretty_print(self):
+        """Prints the stack frame in a human-readable format."""
+        self.location.pretty_print()
 
 
 @dataclasses.dataclass
@@ -157,6 +183,12 @@ class Stack:
             if self.message is not None
             else None,
         )
+
+    def pretty_print(self):
+        """Prints the stack in a human-readable format."""
+        formatter.pretty_print_title(f"Stack: {self.message}", fill_char="-")
+        for frame in self.frames:
+            frame.pretty_print()
 
 
 # This is a workaround for mypy not supporting Self from typing_extensions.
@@ -182,6 +214,9 @@ class Graph:
             properties=PatchedPropertyBag(name=self.name, description=self.description),
         )
 
+    def pretty_print(self):
+        pass
+
 
 @dataclasses.dataclass
 class Diagnostic:
@@ -201,7 +236,7 @@ class Diagnostic:
             message = f"{message}\n{self.additional_message}"
         sarif_result = sarif.Result(
             message=sarif.Message(text=message),
-            level=self.level.value,
+            level=self.level.name.lower(),  # type: ignore[arg-type]
             rule_id=self.rule.id,
         )
         sarif_result.locations = [location.sarif() for location in self.locations]
@@ -234,6 +269,31 @@ class Diagnostic:
         else:
             self.additional_message = f"{self.additional_message}\n{message}"
         return self
+
+    def pretty_print(self, verbose: bool = False, log_level: Level = Level.ERROR):
+        """Prints the diagnostics in a human-readable format.
+
+        Args:
+            verbose: If True, prints all information. E.g. stack frames, graphs, etc.
+                Otherwise, only prints compact information. E.g., rule name and display message.
+            level: The minimum level of diagnostics to print.
+        """
+        if self.level.value < log_level.value:
+            return
+        formatter.pretty_print_item_title(f"{self.level.name}: {self.rule.name}")
+        print(self.message)
+
+        if not verbose:
+            print("<Set verbose=True to see more details>\n")
+            return
+
+        for location in self.locations:
+            location.pretty_print()
+        for stack in self.stacks:
+            stack.pretty_print()
+        for graph in self.graphs:
+            graph.pretty_print()
+        print()
 
 
 @dataclasses.dataclass
@@ -284,12 +344,15 @@ class DiagnosticOptions:
     Options for diagnostic context.
     """
 
+    log_verbose: bool = dataclasses.field(default=False)
+    log_level: Level = dataclasses.field(default=Level.ERROR)
+
 
 @dataclasses.dataclass
 class DiagnosticContext:
     name: str
     version: str
-    options: Optional[DiagnosticOptions] = None
+    options: DiagnosticOptions = dataclasses.field(default_factory=DiagnosticOptions)
     diagnostic_type: Type[Diagnostic] = dataclasses.field(default=Diagnostic)
     diagnostics: List[Diagnostic] = dataclasses.field(init=False, default_factory=list)
     _invocation: Invocation = dataclasses.field(init=False)
@@ -350,3 +413,38 @@ class DiagnosticContext:
         diagnostic = self.diagnostic_type(rule, level, message, **kwargs)
         self.add_diagnostic(diagnostic)
         return diagnostic
+
+    def pretty_print(
+        self, verbose: bool = False, log_level: Level = Level.ERROR
+    ) -> None:
+        """Prints the diagnostics in a human-readable format.
+
+        Args:
+            verbose: Whether to print the diagnostics in verbose mode. See Diagnostic.pretty_print.
+            level: The minimum level of diagnostics to print.
+        """
+        formatter.pretty_print_title(
+            f"Diagnostic Run {self.name} version {self.version}"
+        )
+        print(f"verbose: {verbose}, log level: {log_level}")
+        diagnostic_stats = {level: 0 for level in Level}
+        for diagnostic in self.diagnostics:
+            diagnostic_stats[diagnostic.level] += 1
+        formatter.pretty_print_title(
+            " ".join(f"{diagnostic_stats[level]} {level.name}" for level in Level)
+        )
+
+        for diagnostic in self.diagnostics:
+            diagnostic.pretty_print(verbose, log_level)
+
+        unprinted_diagnostic_stats = [
+            (level, count)
+            for level, count in diagnostic_stats.items()
+            if count > 0 and level.value < log_level.value
+        ]
+        if unprinted_diagnostic_stats:
+            print(
+                f"{' '.join(f'{count} {level.name}' for level, count in unprinted_diagnostic_stats)} "
+                "were not printed due to the log level."
+            )
+        print()

--- a/torch/onnx/_internal/diagnostics/infra/engine.py
+++ b/torch/onnx/_internal/diagnostics/infra/engine.py
@@ -85,8 +85,23 @@ class DiagnosticEngine:
         Returns:
             A new diagnostic context.
         """
+        if options is None:
+            options = infra.DiagnosticOptions()
         context = infra.DiagnosticContext(
             name, version, options, diagnostic_type=diagnostic_type
         )
         self.contexts.append(context)
         return context
+
+    def pretty_print(
+        self, verbose: bool = False, level: infra.Level = infra.Level.ERROR
+    ) -> None:
+        """Pretty prints all diagnostics in the diagnostic contexts.
+
+        Args:
+            verbose: Whether to print the diagnostics in verbose mode. See Diagnostic.pretty_print.
+            level: The minimum level of diagnostics to print.
+        """
+        formatter.pretty_print_title(f"{len(self.contexts)} Diagnostic Run")
+        for context in self.contexts:
+            context.pretty_print(verbose, level)

--- a/torch/onnx/_internal/diagnostics/infra/formatter.py
+++ b/torch/onnx/_internal/diagnostics/infra/formatter.py
@@ -57,3 +57,21 @@ def sarif_to_json(attr_cls_obj: _SarifClass) -> str:
     dict = dataclasses.asdict(attr_cls_obj)
     dict = _convert_key(dict, _camel_case_to_snake_case)
     return json.dumps(dict, indent=4)
+
+
+def pretty_print_title(title: str, width: int = 80, fill_char: str = "=") -> None:
+    """Pretty prints title in below format:
+
+    ==================== title ====================
+    """
+    print(f" {title} ".center(width, fill_char))
+
+
+def pretty_print_item_title(title: str, fill_char: str = "=") -> None:
+    """Pretty prints title in below format:
+
+    title
+    =====
+    """
+    print(title)
+    print(fill_char * len(title))

--- a/torch/onnx/_internal/diagnostics/infra/utils.py
+++ b/torch/onnx/_internal/diagnostics/infra/utils.py
@@ -6,7 +6,7 @@ from torch.onnx._internal.diagnostics.infra import _infra
 def python_frame(frame: inspect.FrameInfo) -> _infra.StackFrame:
     """Returns a StackFrame for the given inspect.FrameInfo."""
     snippet = (
-        frame.code_context[frame.index]
+        frame.code_context[frame.index].strip()
         if frame.code_context is not None and frame.index is not None
         else None
     )


### PR DESCRIPTION
Summary: It presents as a fastpath where common execution paths are executed natively in Pytorch using torch._native_multi_head_attention. At present, the fast path is implemented in [torch.nn.MultiHeadAttention](https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/activation.py).
Change replicates fastpath implementation in torch.nn.functional multi_head_attention_forward.
With some refactoring done to avoid duplication.

Test Plan: buck2 test @//mode/dev-nosan //caffe2/test:jit -- 'jit_multihead_attn_forward (test_jit.TestJit)' test_functional_multi_head_attn_fast_path --print-passing-details

Differential Revision: D40821294